### PR TITLE
Solve dependency issues

### DIFF
--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -1,6 +1,4 @@
-from distutils.core import setup
-from Cython.Build import cythonize
-from distutils.extension import Extension
+from setuptools import setup, Extension
 import numpy as np
 
 # To compile and install locally run "python setup.py build_ext --inplace"
@@ -15,10 +13,15 @@ ext_modules = [
     )
 ]
 
-setup(name='pycocotools',
-      packages=['pycocotools'],
-      package_dir = {'pycocotools': 'pycocotools'},
-      version='2.0',
-      ext_modules=
-          cythonize(ext_modules)
-      )
+setup(
+    name='pycocotools',
+    packages=['pycocotools'],
+    package_dir = {'pycocotools': 'pycocotools'},
+    install_requires=[
+        'setuptools>=18.0',
+        'cython>=0.27.3',
+        'matplotlib>=2.1.0'
+    ],
+    version='2.0',
+    ext_modules= ext_modules
+)


### PR DESCRIPTION
[Why] When we perform `pip install https://github.com/pdollar/coco.git#subdirectory=PythonAPI`,
it requires `matplotlib` and `cython` package.

Although we put cython in our requirements.txt, sadly `pip install
-r requirements` doesn't follow the specified order according to
https://stackoverflow.com/questions/5394356/how-to-specify-install-order-for-python-pip

I wanna change setup.py to install coco python api along with cython.

[How] According to https://stackoverflow.com/questions/37471313/setup-requires-with-cython,
we can use `setuptools` to specify cython as setup_requires and it will
deal with `*.pyx` automatically