### PR TITLE
added which condition for python3

### DIFF
--- a/PythonAPI/Makefile
+++ b/PythonAPI/Makefile
@@ -1,9 +1,9 @@
 all:
     # install pycocotools locally
-	python setup.py build_ext --inplace
+	`(which python3 || which python)` setup.py build_ext --inplace
 	rm -rf build
 
 install:
 	# install pycocotools to the Python site-packages
-	python setup.py build_ext install
+	`(which python3 || which python)` setup.py build_ext install
 	rm -rf build


### PR DESCRIPTION
The script in PythonAPI fails for python3 . This code will support both Python2 and Python3.