### PR TITLE
Define ‘unicode’ in Python 3

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -55,12 +55,16 @@ import itertools
 from . import mask as maskUtils
 import os
 from collections import defaultdict
-import sys
-PYTHON_VERSION = sys.version_info[0]
-if PYTHON_VERSION == 2:
+
+try:                 # Python 2
+    from urllib.request import urlretriev
+except ImportError:  # Python 3
     from urllib import urlretrieve
-elif PYTHON_VERSION == 3:
-    from urllib.request import urlretrieve
+
+try:                 # Python 2
+    unicode
+except NameError:    # Python 3
+    unicode = str  
 
 
 def _isArrayLike(obj):

--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -56,9 +56,9 @@ from . import mask as maskUtils
 import os
 from collections import defaultdict
 
-try:                 # Python 2
-    from urllib.request import urlretriev
-except ImportError:  # Python 3
+try:                 # Python 3
+    from urllib.request import urlretrieve
+except ImportError:  # Python 2
     from urllib import urlretrieve
 
 try:                 # Python 2


### PR DESCRIPTION
This should resolve an _undefined name_ on line 312.  __unicode__ was removed in Python 3 because all __str__ are Unicode.  Follows Python porting best practice [Use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).