### PR TITLE
pip install pycocotools is broken in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+install:
+    - pip install --upgrade pip 
+    - pip install pycocotools
+script:
+    - true


### PR DESCRIPTION
Is there a recommended way to install pycocotools in Travis CI?

Output: https://travis-ci.com/cclauss/cocoapi/builds/72423311
```
0.89s$ pip install pycocotools
Collecting pycocotools
  Downloading https://files.pythonhosted.org/packages/96/84/9a07b1095fd8555ba3f3d519517c8743c2554a245f9476e5e39869f948d2/pycocotools-2.0.0.tar.gz (1.5MB)
    100% |████████████████████████████████| 1.5MB 10.7MB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-6_nKVE/pycocotools/setup.py", line 2, in <module>
        from Cython.Build import cythonize
    ImportError: No module named Cython.Build
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-6_nKVE/pycocotools/
```
