### PR TITLE
State that windows is not supported in README.md

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,5 +11,5 @@ After downloading the images and annotations, run the Matlab, Python, or Lua dem
 
 To install:
 -For Matlab, add coco/MatlabApi to the Matlab path (OSX/Linux binaries provided)
--For Python, run "make" under coco/PythonAPI
+-For Python, run "make" under coco/PythonAPI (Note that Windows is not supported)
 -For Lua, run “luarocks make LuaAPI/rocks/coco-scm-1.rockspec” under coco/


### PR DESCRIPTION
The decision that windows won't be supported has been made a long time ago (See issue #9) but this is stated nowhere except this issue which leads to many confused people that think windows should be supported.