### PR TITLE
fix ignore on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,15 @@ MatlabAPI/analyze*/
 MatlabAPI/visualize*/
 MatlabAPI/private/maskApiMex.*
 
-PythonAPI/pycocotools/__init__.pyc
+# Cython generated C script
 PythonAPI/pycocotools/_mask.c
-PythonAPI/pycocotools/_mask.so
-PythonAPI/pycocotools/coco.pyc
-PythonAPI/pycocotools/cocoeval.pyc
-PythonAPI/pycocotools/mask.pyc
+
+# general C/C++ builds
+*.so
+*.dylib
+*.o
+*.a
+[Bb]uild
+
+# general cache files
+*.pyc


### PR DESCRIPTION
on my macOS (10.13.6), if compile Cython extension by `gcc` or `clang`, the generated shared binary `cocoapi/PythonAPI/pycocotools/_mask.cpython-36m-darwin.so` can't be ignored under current `.ignore`.