### PR TITLE
Fixed error when using custom dataset

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -225,7 +225,9 @@ class COCO:
         :param ids (int array)       : integer ids specifying img
         :return: imgs (object array) : loaded img objects
         """
-        if _isArrayLike(ids):
+        if type(ids) == type(''):
+            return [self.imgs[ids]]
+        elif _isArrayLike(ids):
             return [self.imgs[id] for id in ids]
         elif type(ids) == int:
             return [self.imgs[ids]]


### PR DESCRIPTION
For a custom dataset, it's most likely the images to be named as `string` like `a1.jpg`.
The `if _isArrayLike(ids):` line will makes this error since python see a string as an array.
The `self.imgs` is a `dict` so there's absolutely no reason not to use a `string` as `ids`. 
This edit won't affect the official `int` ids.