### PR TITLE
No longer returns true from _isArraylike if obj is a string

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -64,7 +64,7 @@ elif PYTHON_VERSION == 3:
 
 
 def _isArrayLike(obj):
-    return hasattr(obj, '__iter__') and hasattr(obj, '__len__')
+    return not type(obj) == str and hasattr(obj, '__iter__') and hasattr(obj, '__len__')
 
 
 class COCO:


### PR DESCRIPTION
Strings should not be counted as arraylike in this case (i.e. if we get one string as a key, that should not be counted as an array)