### PR TITLE
NameError: name 'unicode' is not defined when passing numpy array to loadRes instead of json file using python3

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -59,9 +59,9 @@ import sys
 PYTHON_VERSION = sys.version_info[0]
 if PYTHON_VERSION == 2:
     from urllib import urlretrieve
+    str = unicode
 elif PYTHON_VERSION == 3:
     from urllib.request import urlretrieve
-
 
 def _isArrayLike(obj):
     return hasattr(obj, '__iter__') and hasattr(obj, '__len__')
@@ -305,7 +305,7 @@ class COCO:
 
         print('Loading and preparing results...')
         tic = time.time()
-        if type(resFile) == str or (PYTHON_VERSION == 2 and type(resFile) == unicode):
+        if type(resFile) == str:
             anns = json.load(open(resFile))
         elif type(resFile) == np.ndarray:
             anns = self.loadNumpyAnnotations(resFile)


### PR DESCRIPTION
the loadRes file should be able to take a numpy array of (Nx7) as well but there is the condition:

if type(resFile) == str or (PYTHON_VERSION == 2 and type(resFile) == unicode):

so both python version AND unicode need to be checked. However, as unicode does not exist in python3 we get an error

a possible fix is is

str = uniocode when python version is 2